### PR TITLE
cleanup methods in policy

### DIFF
--- a/physbo/search/pareto.py
+++ b/physbo/search/pareto.py
@@ -23,13 +23,9 @@ class Rectangles(object):
         self.ub = np.r_[self.ub, ub]
 
 
-class domination_rule(object):
-    def __init__(self):
-        pass
-
-    def dominate(self, t1, t2):
-        """domination rule for maximization problem"""
-        return np.all(t1 >= t2) and np.any(t1 > t2)
+def dominate(t1, t2):
+    """domination rule for maximization problem"""
+    return np.all(t1 >= t2) and np.any(t1 > t2)
 
 
 class Pareto(object):
@@ -42,7 +38,7 @@ class Pareto(object):
         self.front_updated = False
 
         if self.dom_rule is None:
-            self.dom_rule = domination_rule()
+            self.dom_rule = dominate
 
         self.cells = Rectangles(num_objectives, int)
         self.reference_min = None
@@ -66,7 +62,7 @@ class Pareto(object):
             point = tt[k]
             is_front = True
             for i in range(len(self.front)):
-                if self.dom_rule.dominate(self.front[i], point):
+                if self.dom_rule(self.front[i], point):
                     is_front = False
                     break
 
@@ -74,7 +70,7 @@ class Pareto(object):
                 front_updated = True
                 dom_filter = np.full(len(self.front), True, dtype=bool)
                 for i in range(len(self.front)):
-                    if self.dom_rule.dominate(point, self.front[i]):
+                    if self.dom_rule(point, self.front[i]):
                         dom_filter[i] = False
 
                 self.front = np.r_[self.front[dom_filter], point[np.newaxis, :]]

--- a/physbo/search/utility.py
+++ b/physbo/search/utility.py
@@ -27,36 +27,47 @@ def show_search_results(history, N):
             print("f(x)=%f (action = %d)" % (history.fx[n], history.chosen_actions[n]))
         print("\n")
 
-def show_search_results_mo(history, N, disp_pareto_set = False):
+
+def show_search_results_mo(history, N, disp_pareto_set=False):
     n = history.total_num_search
     pset, step = history.pareto.export_front()
 
-    def msg_pareto_set_updated(indent = False):
-        prefix = '   ' if indent else ''
+    def msg_pareto_set_updated(indent=False):
+        prefix = "   " if indent else ""
         if history.pareto.front_updated:
-            print(prefix + 'Pareto set updated.')
+            print(prefix + "Pareto set updated.")
             if disp_pareto_set:
-                print(prefix + 'current Pareto set = %s (steps = %s) \n'
-                    % (str(pset), str(step + 1)))
+                print(
+                    prefix
+                    + "current Pareto set = %s (steps = %s) \n"
+                    % (str(pset), str(step + 1))
+                )
             else:
-                print(prefix + 'the number of Pareto frontiers = %s \n' % str(len(step)))
+                print(
+                    prefix + "the number of Pareto frontiers = %s \n" % str(len(step))
+                )
 
     if N == 1:
-        print('%04d-th step: f(x) = %s (action = %d)'
-                % (n, str(history.fx[n-1]), history.chosen_actions[n-1]))
+        print(
+            "%04d-th step: f(x) = %s (action = %d)"
+            % (n, str(history.fx[n - 1]), history.chosen_actions[n - 1])
+        )
 
         msg_pareto_set_updated(indent=True)
 
     else:
         msg_pareto_set_updated()
 
-        print('list of simulation results')
+        print("list of simulation results")
         st = history.total_num_search - N
         en = history.total_num_search
         for n in range(st, en):
-            print('f(x) = %s (action = %d)'
-                % (str(history.fx[n-1]), history.chosen_actions[n-1]))
-        print('\n')
+            print(
+                "f(x) = %s (action = %d)"
+                % (str(history.fx[n - 1]), history.chosen_actions[n - 1])
+            )
+        print("\n")
+
 
 def show_start_message_multi_search(N, score=None):
     if score == "EI":
@@ -71,7 +82,7 @@ def show_start_message_multi_search(N, score=None):
 
 def show_interactive_mode(simulator, history):
     if simulator is None and history.total_num_search == 0:
-        print("interactive mode stars ... \n ")
+        print("interactive mode starts ... \n ")
 
 
 def length_vector(t):
@@ -81,8 +92,8 @@ def length_vector(t):
 
 def is_learning(n, interval):
     if interval == 0:
-        return True if n == 0 else False
+        return n==0
     elif interval > 0:
-        return True if np.mod(n, interval) == 0 else False
+        return np.mod(n, interval) == 0
     else:
         return False

--- a/tests/integrated/test_simple_example.py
+++ b/tests/integrated/test_simple_example.py
@@ -53,3 +53,18 @@ def test_bayes_search():
     print(best_action)
     assert best_fx[-1] == pytest.approx(0.0, abs=0.001)
     assert best_action[-1] == 60
+
+
+def test_bayes_search_rand():
+    sim = simulator()
+    nrand = 10
+    nsearch = 5
+    policy = physbo.search.discrete.policy(test_X=sim.X)
+    policy.set_seed(12345)
+    res = policy.random_search(max_num_probes=nrand, simulator=sim)
+    res = policy.bayes_search(max_num_probes=nsearch, simulator=sim, score="TS", num_rand_basis=100)
+    best_fx, best_action = res.export_all_sequence_best_fx()
+    print(best_fx)
+    print(best_action)
+    assert best_fx[-1] == pytest.approx(0.0, abs=0.001)
+    assert best_action[-1] == 60

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -64,7 +64,7 @@ def test_randomsearch(policy, mocker):
 def test_bayes_search(policy, mocker):
     simulator = mocker.MagicMock(side_effect=lambda x: x)
     write_spy = mocker.spy(physbo.search.discrete.policy, "write")
-    get_actions_spy = mocker.spy(physbo.search.discrete.policy, "get_actions")
+    get_actions_spy = mocker.spy(physbo.search.discrete.policy, "_get_actions")
 
     N = 2
 


### PR DESCRIPTION
Clean up some methods not intended to be used from out of class (`discrete.policy` and `discrete_multi.policy`).
Some redundant methods are removed, and others are renamed (add a prefix `_`)