### PR TITLE
Initialize predictor

### DIFF
--- a/physbo/search/discrete/policy.py
+++ b/physbo/search/discrete/policy.py
@@ -314,6 +314,11 @@ class policy:
         """
         if training is None:
             training = self.training
+
+        if training.X is None or training.X.shape[0] == 0:
+            msg = "ERROR: No training data is registered."
+            raise RuntimeError(msg)
+
         if predictor is None:
             predictor = self.predictor
 

--- a/physbo/search/discrete/policy.py
+++ b/physbo/search/discrete/policy.py
@@ -221,6 +221,9 @@ class policy:
         elif self.predictor is None:
             self._init_predictor(is_rand_expans)
 
+        if max_num_probes == 0 and interval >= 0:
+            self._learn_hyperparameter(num_rand_basis)
+
         N = int(num_search_each_probe)
 
         for n in range(max_num_probes):
@@ -313,6 +316,16 @@ class policy:
             training = self.training
         if predictor is None:
             predictor = self.predictor
+
+        if predictor is None:
+            print("Warning: Since policy.predictor is not yet set,")
+            print("         a GP predictor (num_rand_basis=0) is used for calculating scores.")
+            print("         If you want to use a BLM predictor (num_rand_basis>0),")
+            print("         call bayes_search(max_num_probes=0, num_rand_basis=nrb)")
+            print("         before calling get_score().")
+            predictor = gp_predictor(self.config)
+            predictor.fit(training, 0)
+            predictor.prepare(training)
 
         if xs is not None:
             if actions is not None:

--- a/physbo/search/discrete_multi/policy.py
+++ b/physbo/search/discrete_multi/policy.py
@@ -257,6 +257,9 @@ class policy(discrete.policy):
         if pareto is None:
             pareto = self.history.pareto
 
+        if training_list[0].X is None or training_list[0].X.shape[0] == 0:
+            msg = "ERROR: No training data is registered."
+            raise RuntimeError(msg)
 
         if predictor_list == [None] * self.num_objectives:
             print("Warning: Since policy.predictor_list is not yet set,")

--- a/physbo/search/discrete_multi/policy.py
+++ b/physbo/search/discrete_multi/policy.py
@@ -165,7 +165,10 @@ class policy(discrete.policy):
                     gp_predictor(self.config) for i in range(self.num_objectives)
                 ]
         else:
-            self.predictor = predictor_list
+            self.predictor_list = predictor_list
+
+        if max_num_probes == 0 and interval >= 0:
+            self._learn_hyperparameter(num_rand_basis)
 
         N = int(num_search_each_probe)
 
@@ -253,6 +256,18 @@ class policy(discrete.policy):
             training_list = self.training_list
         if pareto is None:
             pareto = self.history.pareto
+
+
+        if predictor_list == [None] * self.num_objectives:
+            print("Warning: Since policy.predictor_list is not yet set,")
+            print("         GP predictors (num_rand_basis=0) is used for calculating scores.")
+            print("         If you want to use BLM predictors (num_rand_basis>0),")
+            print("         call bayes_search(max_num_probes=0, num_rand_basis=nrb)")
+            print("         before calling get_score().")
+            for i in range(self.num_objectives):
+                predictor_list[i] = gp_predictor(self.config)
+                predictor_list[i].fit(training_list[i], 0)
+                predictor_list[i].prepare(training_list[i])
 
         if xs is not None:
             if actions is not None:

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -106,6 +106,9 @@ def test_get_score(policy, mocker):
     PI = mocker.patch("physbo.search.score.PI")
     TS = mocker.patch("physbo.search.score.TS")
 
+    simulator = mocker.MagicMock(return_value=1.0)
+    policy.random_search(2, simulator=simulator)
+
     policy.get_score("EI")
     EI.assert_called_once()
 


### PR DESCRIPTION
When the policy has not yet initialized the predictor, `get_score` fails.
This PR fixes this by making `get_score` use `gp.predictor` in such cases.
If users want to use a `blm.predictor`, they can initialize the predictor by calling `bayes_search(max_num_probes=0, num_rand_basis=nrb)` with `nrb>0`.

This PR also makes `bayes_search(max_num_probes=0, interval=interval)` with `interval>=0` learn hyperparameters of predictor.