### PR TITLE
bug-fix in algorithm for multiple-probe for multiple-objective

### DIFF
--- a/physbo/blm/core/model.py
+++ b/physbo/blm/core/model.py
@@ -187,8 +187,11 @@ class model:
         =======
         numpy.ndarray
         """
+        if Xtest.shape[0] == 0:
+            return np.zeros((0, N))
         fmean = self.post_sampling(Xtest, Psi, N=N)
-        return fmean + np.sqrt(self.lik.cov.sigma2) * np.random.randn(Xtest.shape[0], N)
+        A = np.random.randn(Xtest.shape[0], N)
+        return fmean + np.sqrt(self.lik.cov.sigma2) * A
 
     def get_post_fcov(self, X, Psi=None, diag=True):
         """

--- a/physbo/blm/predictor.py
+++ b/physbo/blm/predictor.py
@@ -181,7 +181,7 @@ class predictor(physbo.predictor.base_predictor):
 
         Returns
         =======
-        numpy.ndarray
+        numpy.ndarray (N x len(test))
         """
         if self.blm.stats is None:
             self.prepare(training)

--- a/physbo/gp/core/model.py
+++ b/physbo/gp/core/model.py
@@ -309,9 +309,9 @@ class model:
         Parameters
         ----------
         X: numpy.ndarray
-            inputs
+            training datasets
         Z: numpy.ndarray
-            feature maps
+            input for sampling objective values
         params: numpy.ndarray
             Parameters
         N: int
@@ -327,6 +327,8 @@ class model:
             params = np.copy(self.params)
 
         ndata = Z.shape[0]
+        if ndata == 0:
+            return np.zeros((N, 0))
         fmean = self.get_post_fmean(X, Z, params=None)
         fcov = self.get_post_fcov(X, Z, params=None, diag=False) + self.lik.get_cov(
             ndata

--- a/physbo/gp/predictor.py
+++ b/physbo/gp/predictor.py
@@ -155,7 +155,7 @@ class predictor(physbo.predictor.base_predictor):
 
         Returns
         -------
-        numpy.ndarray
+        numpy.ndarray (N x len(test))
 
         """
         if self.model.stats is None:


### PR DESCRIPTION
Bug-fix in the proposal of N(>1) actions in one search for a multiple-objective problem,

- Before PR
    - Actions with top N scores are chosen
    - It tends to choose similar actions
- After PR
    - Action with the highest score will be chosen as the first action, x
    - By using the regression models, values of the objective functions `y_i = f_i(x)` of this action are predicted (sampled)
    - After re-training the models by the training dataset with `(x, {y_i})`, the next action will be chosen to maximize the score.
    - This scheme is the same as that already used for a single-objective problem