### PR TITLE
Use numpy<1.20 for installing physbo

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython", "numpy"]
+requires = ["setuptools", "wheel", "cython", "numpy<1.20"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython", "numpy<1.20"]
+requires = ["setuptools", "wheel", "cython", "numpy<1.20; python_version<'3.10'", "numpy; python_version>='3.10'"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This change fixes the problem `ValueError: numpy.ndarray size changed` when numpy is older than 1.20