### PR TITLE
Set the upper bound of numpy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PHYSBO was developed based on [COMBO](https://github.com/tsudalab/combo) for aca
 
 - Python >= 3.6
     - No longer tested with Python 3.6
-- NumPy
+- NumPy < 2.0.0
 - SciPy
 
 ## Install

--- a/docs/sphinx/manual/en/source/install.rst
+++ b/docs/sphinx/manual/en/source/install.rst
@@ -8,7 +8,7 @@ Required Packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Python >= 3.6
-* numpy
+* numpy < 2.0.0
 * scipy
 
 Download and Install

--- a/docs/sphinx/manual/ja/source/install.rst
+++ b/docs/sphinx/manual/ja/source/install.rst
@@ -9,7 +9,7 @@
 PHYSBOの実行環境・必要なパッケージは以下の通りです。
 
 * Python >= 3.6
-* numpy
+* numpy < 2.0.0
 * scipy
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,5 +14,5 @@ packages = find:
 zip_safe = False
 python_requires= >=3.6
 install_requires =
-    numpy
+    numpy < 2.0
     scipy


### PR DESCRIPTION
The new major version of NumPy, v2.0.0, is planned to be released on 16th June 2024.
Numpy 2.0 has some breaking changes, particularly in Python/C API, so we limit the version to be used.