### PR TITLE
Make `get_post_fcov` methods return posterior covariance matrices of Gaussian Process

### DIFF
--- a/physbo/blm/core/model.py
+++ b/physbo/blm/core/model.py
@@ -224,7 +224,7 @@ class model:
         physbo.blm.inf.exact.get_post_fcov
         """
         if self.method == "exact":
-            fcov = inf.exact.get_post_fcov(self, X, Psi, diag=True)
+            fcov = inf.exact.get_post_fcov(self, X, Psi, diag=diag)
         else:
             pass
         return fcov

--- a/physbo/blm/predictor.py
+++ b/physbo/blm/predictor.py
@@ -106,7 +106,7 @@ class predictor(physbo.predictor.base_predictor):
             self.prepare(training)
         return self.blm.get_post_fmean(test.X, test.Z)
 
-    def get_post_fcov(self, training, test):
+    def get_post_fcov(self, training, test, diag=True):
         """
         calculates posterior variance-covariance matrix of model
 
@@ -123,7 +123,7 @@ class predictor(physbo.predictor.base_predictor):
         """
         if self.blm.stats is None:
             self.prepare(training)
-        return self.blm.get_post_fcov(test.X, test.Z)
+        return self.blm.get_post_fcov(test.X, test.Z, diag)
 
     def get_post_params(self, training, test):
         """

--- a/physbo/search/discrete/policy.py
+++ b/physbo/search/discrete/policy.py
@@ -360,7 +360,7 @@ class policy:
             self._update_predictor()
             return self.predictor.get_post_fmean(self.training, X)
 
-    def get_post_fcov(self, xs):
+    def get_post_fcov(self, xs, diag=True):
         """Calculate covariance of predictor (post distribution)"""
         X = self._make_variable_X(xs)
         if self.predictor is None:
@@ -368,10 +368,10 @@ class policy:
             predictor = gp_predictor(self.config)
             predictor.fit(self.training, 0)
             predictor.prepare(self.training)
-            return predictor.get_post_fcov(self.training, X)
+            return predictor.get_post_fcov(self.training, X, diag)
         else:
             self._update_predictor()
-            return self.predictor.get_post_fcov(self.training, X)
+            return self.predictor.get_post_fcov(self.training, X, diag)
 
     def get_score(
         self,


### PR DESCRIPTION
Hi PHYSBO developers! Thank you for developing and maintaining this amazing software.
I am enjoying the usability and efficiency of PHYSBO.
In this pull request, I want to make a tiny contribution.

## Description

Obtain posterior covariance matrices of Gaussian Process

## Changes

Propagate the `diag` flag from `get_post_fcov` methods

## Why is this necessary?

We need a posterior covariance matrix for novel algorithms.

## Demo

<details>
<summary>Click here to expand...</summary>

```python
import numpy as np
import scipy
import physbo
import itertools

window_num=10001
x_max = 2.0
x_min = -2.0

X = np.linspace(x_min,x_max,window_num).reshape(window_num, 1)

class simulator:

    def __call__(self, action):
        action_idx = action[0]
        x = X[action_idx][0]
        fx = 3.0*x**4 + 4.0*x**3 + 1.0
        fx_list.append(fx)
        x_list.append(X[action_idx][0])

        print ("*********************")
        print ("Present optimum interactions")

        print ("x_opt=", x_list[np.argmin(np.array(fx_list))])

        return -fx

policy = physbo.search.discrete.policy(test_X=X)

policy.set_seed(0)

fx_list=[]
x_list = []
res = policy.random_search(
	max_num_probes=20,
	simulator=simulator()
)

res = policy.bayes_search(
	max_num_probes=50,
	simulator=simulator(),
	score='TS',
	interval=0,
	num_rand_basis=500
)

print(policy.get_post_fcov(X, diag=True))
# -> [0.93196067 0.92704693 0.9221549  ... 6.8052756  6.82997947 6.85475494]

print(policy.get_post_fcov(X, diag=False)) # Posterior covariance matrix is returned.
# -> [[0.93196067 0.92949971 0.92704144 ... 0.27751007 0.27805598 0.27860213]
 [0.92949971 0.92704693 0.92459684 ... 0.27633487 0.27687851 0.27742238]
 [0.92704144 0.92459684 0.9221549  ... 0.27516163 0.275703   0.27624459]
 ...
 [0.27751007 0.27633487 0.27516163 ... 6.8052756  6.8176145  6.82996308]
 [0.27805598 0.27687851 0.275703   ... 6.8176145  6.82997947 6.84235414]
 [0.27860213 0.27742238 0.27624459 ... 6.82996308 6.84235414 6.85475494]]
```
</details>