### PR TITLE
Fix inconsistent model parameters in parallel execution

### DIFF
--- a/physbo/blm/predictor.py
+++ b/physbo/blm/predictor.py
@@ -44,6 +44,8 @@ class predictor(physbo.predictor.base_predictor):
             dataset for training
         num_basis: int
             the number of basis (default: self.config.predict.num_basis)
+        comm: MPI.Comm
+            MPI communicator
         """
         if num_basis is None:
             num_basis = self.config.predict.num_basis

--- a/physbo/blm/predictor.py
+++ b/physbo/blm/predictor.py
@@ -34,7 +34,7 @@ class predictor(physbo.predictor.base_predictor):
         super(predictor, self).__init__(config, model)
         self.blm = None
 
-    def fit(self, training, num_basis=None):
+    def fit(self, training, num_basis=None, comm=None):
         """
         fit model to training dataset
 
@@ -50,8 +50,8 @@ class predictor(physbo.predictor.base_predictor):
 
         if self.model.prior.cov.num_dim is None:
             self.model.prior.cov.num_dim = training.X.shape[1]
-        self.model.fit(training.X, training.t, self.config)
-        self.blm = self.model.export_blm(num_basis)
+        self.model.fit(training.X, training.t, self.config, comm=comm)
+        self.blm = self.model.export_blm(num_basis, comm=comm)
         self.delete_stats()
 
     def prepare(self, training):

--- a/physbo/gp/core/model.py
+++ b/physbo/gp/core/model.py
@@ -120,6 +120,8 @@ class model:
         ----------
         num_basis: int
             Total number of basis
+        comm: MPI.Comm
+            MPI communicator
         Returns
         -------
         physbo.blm.core.model
@@ -409,6 +411,8 @@ class model:
             N dimensional array.
             The negative energy of each search candidate (value of the objective function to be optimized).
         config: physbo.misc.set_config object
+        comm: MPI.Comm
+            MPI communicator
 
         """
         method = config.learning.method

--- a/physbo/gp/predictor.py
+++ b/physbo/gp/predictor.py
@@ -34,7 +34,6 @@ class predictor(physbo.predictor.base_predictor):
             Not used for gp.model
             the number of basis (default: self.config.predict.num_basis)
         comm: MPI.Comm
-            Not used for gp.model
             MPI communicator
         """
         if self.model.prior.cov.num_dim is None:

--- a/physbo/gp/predictor.py
+++ b/physbo/gp/predictor.py
@@ -22,7 +22,7 @@ class predictor(physbo.predictor.base_predictor):
         """
         super(predictor, self).__init__(config, model)
 
-    def fit(self, training, num_basis=None):
+    def fit(self, training, num_basis=None, comm=None):
         """
         Fitting model to training dataset
 
@@ -31,11 +31,15 @@ class predictor(physbo.predictor.base_predictor):
         training: physbo.variable
             dataset for training
         num_basis: int
+            Not used for gp.model
             the number of basis (default: self.config.predict.num_basis)
+        comm: MPI.Comm
+            Not used for gp.model
+            MPI communicator
         """
         if self.model.prior.cov.num_dim is None:
             self.model.prior.cov.num_dim = training.X.shape[1]
-        self.model.fit(training.X, training.t, self.config)
+        self.model.fit(training.X, training.t, self.config, comm=comm)
         self.delete_stats()
 
     def get_basis(self, *args, **kwds):

--- a/physbo/search/discrete/policy.py
+++ b/physbo/search/discrete/policy.py
@@ -367,7 +367,7 @@ class policy:
         if self.predictor is None:
             self._warn_no_predictor("get_post_fmean()")
             predictor = gp_predictor(self.config)
-            predictor.fit(self.training, 0)
+            predictor.fit(self.training, 0, comm=self.mpicomm)
             predictor.prepare(self.training)
             return predictor.get_post_fmean(self.training, X)
         else:
@@ -396,7 +396,7 @@ class policy:
         if self.predictor is None:
             self._warn_no_predictor("get_post_fcov()")
             predictor = gp_predictor(self.config)
-            predictor.fit(self.training, 0)
+            predictor.fit(self.training, 0, comm=self.mpicomm)
             predictor.prepare(self.training)
             return predictor.get_post_fcov(self.training, X, diag)
         else:
@@ -466,7 +466,7 @@ class policy:
             if self.predictor is None:
                 self._warn_no_predictor("get_score()")
                 predictor = gp_predictor(self.config)
-                predictor.fit(training, 0)
+                predictor.fit(training, 0, comm=self.mpicomm)
                 predictor.prepare(training)
             else:
                 self._update_predictor()
@@ -778,7 +778,7 @@ class policy:
             self.predictor = gp_predictor(self.config)
 
     def _learn_hyperparameter(self, num_rand_basis):
-        self.predictor.fit(self.training, num_rand_basis)
+        self.predictor.fit(self.training, num_rand_basis, comm=self.mpicomm)
         self.test.Z = self.predictor.get_basis(self.test.X)
         self.training.Z = self.predictor.get_basis(self.training.X)
         self.predictor.prepare(self.training)

--- a/physbo/search/discrete_multi/policy.py
+++ b/physbo/search/discrete_multi/policy.py
@@ -316,7 +316,7 @@ class policy(discrete.policy):
             predictor_list = []
             for i in range(self.num_objectives):
                 predictor = gp_predictor(self.config)
-                predictor.fit(self.training_list[i], 0)
+                predictor.fit(self.training_list[i], 0, comm=self.mpicomm)
                 predictor.prepare(self.training_list[i])
                 predictor_list.append(predictor)
         else:
@@ -352,7 +352,7 @@ class policy(discrete.policy):
             predictor_list = []
             for i in range(self.num_objectives):
                 predictor = gp_predictor(self.config)
-                predictor.fit(self.training_list[i], 0)
+                predictor.fit(self.training_list[i], 0, comm=self.mpicomm)
                 predictor.prepare(self.training_list[i])
                 predictor_list.append(predictor)
         else:
@@ -395,7 +395,7 @@ class policy(discrete.policy):
                 predictor_list = []
                 for i in range(self.num_objectives):
                     predictor = gp_predictor(self.config)
-                    predictor.fit(training_list[i], 0)
+                    predictor.fit(training_list[i], 0, comm=self.mpicomm)
                     predictor.prepare(training_list[i])
                     predictor_list.append(predictor)
             else:
@@ -569,7 +569,7 @@ class policy(discrete.policy):
             training = m["training"]
             test = m["test"]
 
-            predictor.fit(training, num_rand_basis)
+            predictor.fit(training, num_rand_basis, comm=self.mpicomm)
             test.Z = predictor.get_basis(test.X)
             training.Z = predictor.get_basis(training.X)
             predictor.prepare(training)


### PR DESCRIPTION
This PR fixes a minor issue where model parameters could become inconsistent across MPI processes during parallel execution. 
It could lead to noticeable differences in generating the post distribution when:

- Training with small datasets
- Training with biased/unbalanced data distributions

This inconsistency had minimal impact on the Bayesian optimization results.

This bug fix is backward compatible as the `comm` parameter defaults to `None`, maintaining the original behavior for non-MPI usage.
