### PR TITLE
`initial_data` argument of `range.Policy`

### DIFF
--- a/src/physbo/search/range/_history.py
+++ b/src/physbo/search/range/_history.py
@@ -88,14 +88,14 @@ class History:
         self.fx[st:en] = t
         self.action_X[st:en, :] = action_X
 
-        if st == 0:
-            self.best_index[0] = 0
-        else:
-            for n in range(st, en):
-                if self.fx[n] > self.fx[self.best_index[n - 1]]:
-                    self.best_index[n] = n
-                else:
-                    self.best_index[n] = self.best_index[n - 1]
+        for n in range(st, en):
+            if n == 0:
+                self.best_index[0] = 0
+                continue
+            if self.fx[n] > self.fx[self.best_index[n - 1]]:
+                self.best_index[n] = n
+            else:
+                self.best_index[n] = self.best_index[n - 1]
 
         self.num_runs += 1
         self.total_num_search += N

--- a/src/physbo/search/range/_policy.py
+++ b/src/physbo/search/range/_policy.py
@@ -76,10 +76,7 @@ class Policy:
             assert init_X.shape[1] == self.dim, (
                 "The dimension of initial_data[0] must be the same as the dimension of min_X and max_X"
             )
-            ## TODO: add initial data to the history
-            ## The following code is for discrete search
-            ## self.write(init_X, fs_normalized)
-            ## self.actions = np.array(sorted(list(set(self.actions) - set(actions))))
+            self.write(init_X, fs_normalized)
 
         if comm is None:
             self.mpicomm = None

--- a/src/physbo/search/range_multi/_policy.py
+++ b/src/physbo/search/range_multi/_policy.py
@@ -66,11 +66,11 @@ class Policy(range_single.Policy):
             assert init_X.shape[1] == self.dim, (
                 "The dimension of initial_data[0] must be the same as the dimension of min_X and max_X"
             )
+            assert fs.shape[1] == self.num_objectives, (
+                "The number of objectives in initial_data[1] must be the same as num_objectives"
+            )
 
-            ## TODO: add initial data to the history
-            ## The following code is for discrete search
-            ## self.write(actions, fs)
-            ## self.actions = np.array(sorted(list(set(self.actions) - set(actions))))
+            self.write(init_X, fs)
 
         if comm is None:
             self.mpicomm = None

--- a/tests/integrated/test_interactive_example.py
+++ b/tests/integrated/test_interactive_example.py
@@ -65,3 +65,22 @@ def test_interactive():
     print(best_action)
     assert best_fx[-1] == pytest.approx(0.0, abs=0.001)
     assert best_action[-1] == 60
+
+
+def test_policy_with_initial_data():
+    sim = simulator()
+    nrand = 10
+    policy = physbo.search.discrete.Policy(test_X=sim.X)
+    policy.set_seed(12345)
+
+    actions = policy.random_search(
+        max_num_probes=1, num_search_each_probe=nrand, simulator=None
+    )
+    targets = sim(actions)
+
+    policy_2 = physbo.search.discrete.Policy(test_X=sim.X, initial_data=(actions, targets))
+    best_fx, best_action = policy_2.history.export_all_sequence_best_fx()
+    ref_best_fx = np.max(targets)
+    ref_best_action = actions[np.argmax(targets)]
+    assert best_fx[-1] == pytest.approx(ref_best_fx, abs=0.001)
+    assert np.allclose(best_action[-1], ref_best_action, atol=0.1)

--- a/tests/integrated/test_interactive_range.py
+++ b/tests/integrated/test_interactive_range.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2020- The University of Tokyo
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from __future__ import print_function
+
+from itertools import product
+
+import numpy as np
+import pytest
+
+physbo = pytest.importorskip("physbo")
+
+
+def sim(x):
+    return -np.sum(x**2, axis=1)
+
+
+def test_interactive():
+    nrand = 10
+    nsearch = 1
+    min_X = np.array([-1.0, -1.0])
+    max_X = np.array([1.0, 1.0])
+    policy = physbo.search.range.Policy(min_X=min_X, max_X=max_X)
+    policy.set_seed(12345)
+
+    actions = policy.random_search(
+        max_num_probes=1, num_search_each_probe=nrand, simulator=None
+    )
+    targets = sim(actions)
+    print(actions)
+    print(targets)
+    policy.write(actions, targets)
+    physbo.search.utility.show_search_results(policy.history, nrand)
+
+    actions = policy.bayes_search(
+        max_num_probes=1, num_search_each_probe=nsearch, simulator=None, score="TS"
+    )
+    targets = sim(actions)
+    print(actions)
+    print(targets)
+    policy.write(actions, targets)
+    physbo.search.utility.show_search_results(policy.history, nsearch)
+
+    res = policy.history
+    best_fx, best_action = res.export_all_sequence_best_fx()
+    ref_best_fx = -0.05486187932603481
+    ref_best_action = np.array([0.1354500581633733, 0.1910894059585031])
+    assert best_fx[-1] == pytest.approx(ref_best_fx, abs=0.001)
+    assert np.allclose(best_action[-1], ref_best_action, atol=0.1)
+
+
+def test_policy_with_initial_data():
+    min_X = np.array([-1.0, -1.0])
+    max_X = np.array([1.0, 1.0])
+    solution = np.array([[0.0, 0.0]])
+    solution_target = sim(solution)
+    action = np.array([[1.0, 1.0], solution[0, :], [-1.0, -1.0]])
+    target = sim(action)
+    print(action)
+    print(target)
+    policy = physbo.search.range.Policy(min_X=min_X, max_X=max_X, initial_data=(action, target))
+    best_fx, best_action = policy.history.export_all_sequence_best_fx()
+    print(best_action)
+    assert best_fx[-1] == pytest.approx(solution_target, abs=0.001)
+    assert np.allclose(best_action[-1], solution, atol=0.1)


### PR DESCRIPTION
This PR fixes the following bugs:

- Passing `initial_data` keyword argument of `range.Policy` caused a runtime error.
- `range.history.write` failed to find the best fx when two or more actions are given at the first time.

<details>
<summary>Summary generated by Copilot</summary>

This pull request improves how initial data is handled in both discrete and range search policies, ensuring that provided initial samples are properly integrated into the search history. It also adds new integrated tests for range-based policies, including validation of initial data handling. The changes increase robustness and test coverage, particularly around initialization logic.

**Initial Data Handling Improvements:**

* In `src/physbo/search/range/_policy.py`, initial data passed to the constructor is now immediately written to the policy history, ensuring consistency with discrete search logic.
* In `src/physbo/search/range_multi/_policy.py`, an assertion is added to verify that the number of objectives in the initial data matches the expected number, and initial data is written to history upon construction.
* In `src/physbo/search/range/_history.py`, the logic for updating the best index in history is refactored for correctness and clarity when processing initial data.

**Test Coverage Enhancements:**

* A new integrated test file, `tests/integrated/test_interactive_range.py`, is added to verify interactive behavior and correct handling of initial data for range-based policies.
* In `tests/integrated/test_interactive_example.py`, a new test is added to confirm that discrete policies correctly handle initial data and compute the best action and value accordingly. 

</details>
