### PR TITLE
Improve docstrings to enrich the API reference

### DIFF
--- a/src/physbo/misc/_centering.py
+++ b/src/physbo/misc/_centering.py
@@ -5,6 +5,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Centering / normalization helpers for input and target arrays."""
+
 import numpy as np
 
 

--- a/src/physbo/misc/_gauss_elim.py
+++ b/src/physbo/misc/_gauss_elim.py
@@ -5,6 +5,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Triangular solve helper used by the exact GP/BLM inference."""
+
 import scipy
 
 

--- a/src/physbo/misc/_matrix.py
+++ b/src/physbo/misc/_matrix.py
@@ -5,6 +5,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Small matrix utilities (diagonal of products and weighted traces)."""
+
 import numpy as np
 
 def diagAB(A, B):

--- a/src/physbo/misc/permutation_importance.py
+++ b/src/physbo/misc/permutation_importance.py
@@ -5,6 +5,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Permutation feature importance for trained predictors."""
+
 import numpy as np
 
 

--- a/src/physbo/opt/_adam.py
+++ b/src/physbo/opt/_adam.py
@@ -5,6 +5,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Adam stochastic optimizer used for hyperparameter learning."""
+
 import numpy as np
 
 
@@ -37,8 +39,10 @@ class Adam:
 
         Parameters
         ==========
-        params:
-        grad:
+        params: numpy.ndarray
+            Initial input vector ``x``.
+        grad: callable
+            Gradient function ``g(x) = f'(x)``; called as ``grad(params, *args, **kwargs)``.
         options: dict
             Hyperparameters for the adam method
 
@@ -57,6 +61,13 @@ class Adam:
         self.epoch = 0
 
     def set_params(self, params):
+        """Set the current input vector.
+
+        Parameters
+        ==========
+        params: numpy.ndarray
+            New input vector ``x``.
+        """
         self.params = params
 
     def update(self, params, *args, **kwargs):
@@ -86,6 +97,13 @@ class Adam:
         return -self.alpha * hat_m / (np.sqrt(hat_v) + self.epsilon)
 
     def run(self, *args, **kwargs):
+        """Run ``max_epoch`` update steps in place on ``self.params``.
+
+        Parameters
+        ==========
+        args, kwargs:
+            Passed through to ``self.grad`` at each step.
+        """
         params = self.params
         for epoch in range(self.max_epoch):
             update = self.update(params, *args, **kwargs)

--- a/src/physbo/search/utility.py
+++ b/src/physbo/search/utility.py
@@ -5,6 +5,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Utility helpers for the search module.
+
+This module collects helpers used across the search policies:
+
+* :class:`Simulator` wraps a test function so it can be called by action index.
+* :func:`make_grid` builds a grid of candidate points for a discrete search.
+* :func:`plot_pareto_front` and :func:`plot_pareto_front_all` visualize the
+  Pareto front stored in a multi-objective history.
+* the remaining ``show_*`` / ``is_learning`` helpers format progress messages
+  and drive the search loop.
+"""
+
 from __future__ import annotations
 
 import itertools
@@ -320,32 +332,106 @@ def plot_pareto_front_all(
 
 
 def show_search_results(history, N):
+    """Print a summary of the last ``N`` single-objective search steps.
+
+    Arguments
+    =========
+    history: History
+        The search history.
+    N: int
+        Number of most recent steps to display. Capped at the total number of
+        searches performed so far.
+    """
     n = min(N, history.total_num_search)
     history.show_search_results(n)
 
 
 def show_search_results_mo(history, N, disp_pareto_set=False):
+    """Print a summary of the last ``N`` multi-objective search steps.
+
+    Arguments
+    =========
+    history: History
+        The multi-objective search history.
+    N: int
+        Number of most recent steps to display. Capped at the total number of
+        searches performed so far.
+    disp_pareto_set: bool, default=False
+        If True, also display the current Pareto set.
+    """
     n = min(N, history.total_num_search)
     history.show_search_results_mo(n, disp_pareto_set)
 
 
 def show_start_message_multi_search(N, score=None):
+    """Print the header announcing a multiple-probe search step.
+
+    Arguments
+    =========
+    N: int
+        Zero-based index of the current search round; the printed index is
+        ``N + 1``.
+    score: str, optional
+        Name of the acquisition function. If None, ``"random"`` is shown.
+    """
     if score is None:
         score = "random"
     print(f"{N + 1:04}-th multiple probe search ({score})")
 
 
 def show_interactive_mode(simulator, history):
+    """Print a message when an interactive search session starts.
+
+    The message is shown only at the very first step (empty history) of an
+    interactive run, i.e. when no simulator is provided.
+
+    Arguments
+    =========
+    simulator: callable or None
+        The simulator, or None for interactive mode.
+    history: History
+        The search history.
+    """
     if simulator is None and history.total_num_search == 0:
         print("interactive mode starts ... \n ")
 
 
 def length_vector(t):
+    """Return the number of elements of ``t``.
+
+    Arguments
+    =========
+    t: array-like or scalar
+        Input object.
+
+    Returns
+    =======
+    int
+        ``len(t)`` if ``t`` is sized, otherwise 1 (treating ``t`` as a scalar).
+    """
     N = len(t) if hasattr(t, "__len__") else 1
     return N
 
 
 def is_learning(n, interval):
+    """Decide whether to (re)learn the hyperparameters at search step ``n``.
+
+    Arguments
+    =========
+    n: int
+        Zero-based index of the current search step.
+    interval: int
+        Hyperparameter learning interval.
+
+        * ``interval == 0``: learn only at the first step (``n == 0``).
+        * ``interval > 0``: learn every ``interval`` steps.
+        * ``interval < 0``: never learn.
+
+    Returns
+    =======
+    bool
+        True if hyperparameters should be learned at this step.
+    """
     if interval == 0:
         return n == 0
     elif interval > 0:


### PR DESCRIPTION
## Summary
Documentation-only improvements (no logic changes). Adds module/function docstrings that feed the auto-generated Sphinx API reference for **both** languages:

- `search/utility.py`: module docstring + docstrings for the previously-undocumented helpers (`show_search_results`, `show_search_results_mo`, `show_start_message_multi_search`, `show_interactive_mode`, `length_vector`, `is_learning`).
- `opt/_adam.py`: module docstring, filled-in `__init__` parameter descriptions, documented `set_params`/`run`.
- `misc/_centering`, `_gauss_elim`, `_matrix`, `permutation_importance`: module-level docstrings.

Verified with a warnings-as-errors autodoc build. Reviewed with Codex (no findings).

Note: the README updates (badges/logo + API reference links) that were previously on this branch have been applied directly to `master` and `develop`, so this PR is now docstrings-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)