### PR TITLE
Add trove classifiers to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,19 @@ license = "MPL-2.0"
 authors = [ { name = "PHYSBO developers", email = "physbo-dev@issp.u-tokyo.ac.jp" } ]
 
 requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Physics",
+]
 dependencies = [
     "numpy",
     "odat-se>=3.2.0",


### PR DESCRIPTION
## Summary
The published `physbo` package declares **no trove classifiers**, so PyPI and shields.io cannot report supported Python versions — the README `pypi/pyversions` badge rendered as *missing* (that badge reads classifiers, not `requires-python`).

This adds classifiers to `pyproject.toml`:
- `Programming Language :: Python :: 3.9` – `3.13` (matching the CI test matrix and `requires-python >=3.9`)
- `Programming Language :: Python :: 3`
- `Development Status :: 5 - Production/Stable`, `Intended Audience :: Science/Research`, `Operating System :: OS Independent`, `Topic :: Scientific/Engineering`, `Topic :: Scientific/Engineering :: Physics`

No `License ::` classifier is added on purpose — the project uses the PEP 639 SPDX form (`license = "MPL-2.0"`), and adding a license classifier would conflict.

## Verification
Built the wheel and inspected `METADATA`: all classifiers are present alongside `License-Expression: MPL-2.0` and `Requires-Python: >=3.9`, with no build error or license/classifier conflict.

## Note
This takes effect for the **next PyPI release**. In the meantime, the README badge was switched to a static "python: 3.9+" badge (already on `master`/`develop`); once a release with these classifiers is published, the badge can be reverted to the dynamic `pypi/pyversions` form if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)