### PR TITLE
Treat non-finite objective values as failed observations

### DIFF
--- a/docs/sphinx/manual/en/source/install.rst
+++ b/docs/sphinx/manual/en/source/install.rst
@@ -101,6 +101,8 @@ In PHYSBO, the following steps are used to perform the optimization (please refe
 
  For searching candidates defined above, define a simulator that gives the objective function values (values to be optimized, such as material property values) for each search candidate. In PHYSBO, the direction of optimization is to maximize the objective function, so if you want to minimize the objective function, you can do so by applying a negative value to the value returned by the simulator.
 
+ If an evaluation fails (for example, a simulation diverges or an experiment cannot be carried out), the simulator can return ``NaN`` (or an infinite value) as the objective function value. Such an evaluation is treated as a *failed observation*: the candidate is recorded in the history and is never proposed again, but the value is excluded from the training data of the Gaussian process, from the best-value tracking, and, in multi-objective optimization, from the Pareto front. In multi-objective optimization, an evaluation is regarded as failed if any of its objective values is not finite.
+
 3. Performing optimization
 
  First, set the optimization policy (the search space is passed to policy as an argument at this stage). You can choose between the following two optimization methods.
@@ -130,10 +132,11 @@ In PHYSBO, the following steps are used to perform the optimization (please refe
 
   The search result ``res`` is returned as an object of the ``history`` class ( ``physbo.search.discrete.results.history`` ). The following is a reference to the search results.
 
-  - ``res.fx``: The logs of evaluation values for simulator (objective function) simulator.
+  - ``res.fx``: The logs of evaluation values for simulator (objective function) simulator. Failed observations are stored as ``NaN`` (or the infinite value returned by the simulator).
   - ``res.chosen_actions``: The logs of the action ID (parameter) when the simulator has executed.
-  - ``fbest, best_action= res.export_all_sequence_best_fx()``: The logs of the best values and their action IDs (parameters) at each step where the simulator has executed.
-  - ``res.total_num_search``: Total number steps where the simulator has executed.
+  - ``fbest, best_action= res.export_all_sequence_best_fx()``: The logs of the best values and their action IDs (parameters) at each step where the simulator has executed. Failed observations are skipped; until the first successful evaluation, the best value is ``NaN`` and the action ID is ``-1``.
+  - ``res.total_num_search``: Total number steps where the simulator has executed (including failed ones).
+  - ``res.valid_mask``: A boolean array marking the successful (``True``) and failed (``False``) observations; ``actions, fx = res.export_valid()`` returns the successful observations only.
 
   The ``policy`` after Bayesian optimization can be saved to external files using the ``save`` method, and the ``policy`` can be loaded from them by using the ``load`` method.
   See the `"Running PHYSBO Interactively" <notebook/tutorial_interactive_mode.html>`_ section of the tutorial for details on how to use it.

--- a/docs/sphinx/manual/ja/source/install.rst
+++ b/docs/sphinx/manual/ja/source/install.rst
@@ -105,6 +105,8 @@ PHYSBO では以下の手順により最適化を実行します(それぞれの
 
   上で定義した探索候補に対して、各探索候補の目的関数値（材料特性値など最適化したい値）を与えるsimulatorを定義します。PHYSBOでは、最適化の方向は「目的関数の最大化」になります。目的関数を最小化したい場合には、simulatorから返す値にマイナスをかけてください。
 
+  評価に失敗した場合（シミュレーションが発散した、実験が実施できなかった、など）には、simulator は目的関数値として ``NaN`` （または無限大）を返すことができます。このような評価は「失敗した観測」として扱われます。すなわち、その候補は履歴に記録され、再び提案されることはありませんが、その値はガウス過程の学習データ、ベスト値の追跡、および多目的最適化における Pareto フロントからは除外されます。多目的最適化では、いずれかの目的関数値が有限でなければ、その評価は失敗とみなされます。
+
 3. 最適化の実行
 
   最初に、最適化の policy をセットします(探索空間はこの段階で引数としてpolicyに渡されます)。最適化方法は、以下の2種類から選択します。
@@ -132,10 +134,11 @@ PHYSBO では以下の手順により最適化を実行します(それぞれの
 
   探索結果 res は history クラスのオブジェクト (``physbo.search.discrete.results.History``) として返されます。以下より探索結果を参照します。
 
-  - ``res.fx`` : simulator (目的関数) の評価値の履歴。
+  - ``res.fx`` : simulator (目的関数) の評価値の履歴。失敗した観測は ``NaN`` （または simulator が返した無限大）のまま記録されます。
   - ``res.chosen_actions``: simulator を評価したときのaction ID(パラメータ)の履歴。
-  - ``fbest, best_action = res.export_all_sequence_best_fx()``: simulator を評価した全タイミングにおけるベスト値とそのaction ID(パラメータ)の履歴。
-  - ``res.total_num_search``: simulator のトータル評価数。
+  - ``fbest, best_action = res.export_all_sequence_best_fx()``: simulator を評価した全タイミングにおけるベスト値とそのaction ID(パラメータ)の履歴。失敗した観測は無視されます。最初に成功した評価までは、ベスト値は ``NaN`` 、action ID は ``-1`` になります。
+  - ``res.total_num_search``: simulator のトータル評価数（失敗した評価を含む）。
+  - ``res.valid_mask``: 成功した観測を ``True`` 、失敗した観測を ``False`` とする論理値配列。 ``actions, fx = res.export_valid()`` で成功した観測のみを取り出せます。
 
   また、ベイズ最適化後の ``policy`` は ``save`` メソッドにより外部ファイルに保存でき、 ``load`` メソッドを用いてファイルからロード・再開することができます。使用方法の詳細はチュートリアルの `「インタラクティブに実行する」 <notebook/tutorial_interactive_mode.html>`_ をご覧ください。
 

--- a/src/physbo/search/discrete/_history.py
+++ b/src/physbo/search/discrete/_history.py
@@ -42,6 +42,36 @@ class History:
     def time_run_simulator(self):
         return copy.copy(self.time_run_simulator_[0 : self.num_runs])
 
+    @property
+    def valid_mask(self):
+        """
+        Mask of valid observations (True) vs failed ones (False).
+
+        An observation is failed when its objective value is not finite
+        (NaN or +-Inf). Failed observations are kept in the history but
+        excluded from the training data and the best-value tracking.
+
+        Returns
+        -------
+        numpy.ndarray of bool, shape (total_num_search,)
+        """
+        return utility.finite_mask(self.fx[0 : self.total_num_search])
+
+    def export_valid(self):
+        """
+        Export the valid (successfully evaluated) observations.
+
+        Returns
+        -------
+        actions: numpy.ndarray
+            Indexes of the actions of the valid observations.
+        fx: numpy.ndarray
+            Objective values of the valid observations.
+        """
+        N = self.total_num_search
+        mask = self.valid_mask
+        return self.chosen_actions[0:N][mask], self.fx[0:N][mask]
+
     def write(
         self,
         t,
@@ -118,12 +148,13 @@ class History:
         best_fx: numpy.ndarray
         best_actions: numpy.ndarray
         """
+        all_best_fx, all_best_actions = self.export_all_sequence_best_fx()
         best_fx = np.zeros(self.num_runs, dtype=float)
         best_actions = np.zeros(self.num_runs, dtype=int)
         for n in range(self.num_runs):
-            index = np.argmax(self.fx[0 : self.terminal_num_run[n]])
-            best_actions[n] = self.chosen_actions[index]
-            best_fx[n] = self.fx[index]
+            index = self.terminal_num_run[n] - 1
+            best_fx[n] = all_best_fx[index]
+            best_actions[n] = all_best_actions[index]
 
         return best_fx, best_actions
 
@@ -137,18 +168,19 @@ class History:
         best_fx: numpy.ndarray
         best_actions: numpy.ndarray
         """
-        best_fx = np.zeros(self.total_num_search, dtype=float)
-        best_actions = np.zeros(self.total_num_search, dtype=int)
-        best_fx[0] = self.fx[0]
-        best_actions[0] = self.chosen_actions[0]
+        # Failed observations (non-finite fx) are skipped. Until the first
+        # valid observation, best_fx is NaN and best_actions is -1.
+        best_fx = np.full(self.total_num_search, np.nan, dtype=float)
+        best_actions = np.full(self.total_num_search, -1, dtype=int)
 
-        for n in range(1, self.total_num_search):
-            if best_fx[n - 1] < self.fx[n]:
-                best_fx[n] = self.fx[n]
-                best_actions[n] = self.chosen_actions[n]
-            else:
+        for n in range(self.total_num_search):
+            if n > 0:
                 best_fx[n] = best_fx[n - 1]
                 best_actions[n] = best_actions[n - 1]
+            fx = self.fx[n]
+            if np.isfinite(fx) and (np.isnan(best_fx[n]) or best_fx[n] < fx):
+                best_fx[n] = fx
+                best_actions[n] = self.chosen_actions[n]
 
         return best_fx, best_actions
 
@@ -198,22 +230,23 @@ class History:
 
     def show_search_results(self, N):
         n = self.total_num_search
-        index = np.argmax(self.fx[0:n])
+        best_fx, best_actions = self.export_all_sequence_best_fx()
+        if np.isfinite(best_fx[n - 1]):
+            best_msg = "current best f(x) = %f (best action=%d)" % (
+                best_fx[n - 1],
+                best_actions[n - 1],
+            )
+        else:
+            best_msg = "current best f(x) = (no valid observation yet)"
 
         if N == 1:
             print(
                 "%04d-th step: f(x) = %f (action=%d)"
                 % (n, self.fx[n - 1], self.chosen_actions[n - 1])
             )
-            print(
-                "   current best f(x) = %f (best action=%d) \n"
-                % (self.fx[index], self.chosen_actions[index])
-            )
+            print("   " + best_msg + " \n")
         else:
-            print(
-                "current best f(x) = %f (best action = %d) "
-                % (self.fx[index], self.chosen_actions[index])
-            )
+            print(best_msg + " ")
 
             print("list of simulation results")
             st = self.total_num_search - N

--- a/src/physbo/search/discrete/_policy.py
+++ b/src/physbo/search/discrete/_policy.py
@@ -166,6 +166,10 @@ class Policy:
             N dimensional array (1D) or N x k dimensional array (2D).
             The negative energy of each search candidate (value of the objective function to be optimized).
             Will be normalized to (N, 1) shape internally.
+            A non-finite value (NaN or +-Inf) marks a failed evaluation:
+            the action is recorded in the history and consumed, but the
+            observation is excluded from the training data and the
+            best-value tracking.
         X:  numpy.ndarray
             N x d dimensional matrix. Each row of X denotes the d-dimensional feature vector of each search candidate.
         time_total: numpy.ndarray
@@ -216,7 +220,15 @@ class Policy:
             time_get_action=time_get_action,
             time_run_simulator=time_run_simulator,
         )
-        self.training.add(X=X, t=t_normalized, Z=Z)
+
+        # Failed observations (non-finite t) are kept in the history and
+        # their actions are consumed, but they are not used for training.
+        valid = utility.finite_mask(t_normalized)
+        X_ok = np.asarray(X)[valid]
+        t_ok = t_normalized[valid]
+        Z_ok = utility.mask_rows(Z, valid)
+        if np.any(valid):
+            self.training.add(X=X_ok, t=t_ok, Z=Z_ok)
 
         # remove the selected actions from the list of candidates if exists
         if len(self.actions) > 0:
@@ -226,10 +238,11 @@ class Policy:
             ]
             self.actions = self._delete_actions(local_index)
 
-        if self.new_data is None:
-            self.new_data = Variable(X=X, t=t_normalized, Z=Z)
-        else:
-            self.new_data.add(X=X, t=t_normalized, Z=Z)
+        if np.any(valid):
+            if self.new_data is None:
+                self.new_data = Variable(X=X_ok, t=t_ok, Z=Z_ok)
+            else:
+                self.new_data.add(X=X_ok, t=t_ok, Z=Z_ok)
 
     def random_search(
         self, max_num_probes, num_search_each_probe=1, simulator=None, is_disp=True
@@ -835,9 +848,9 @@ class Policy:
         self.history.load(file_history)
 
         if file_training is None:
-            N = self.history.total_num_search
-            X = self.test.X[self.history.chosen_actions[0:N], :]
-            t = self.history.fx[0:N]
+            # rebuild the training data from the valid observations only
+            actions, t = self.history.export_valid()
+            X = self.test.X[actions, :]
             # Normalize t to (N, 1) shape
             t_normalized = normalize_t(t, k=1)
             self.training = Variable(X=X, t=t_normalized)

--- a/src/physbo/search/discrete_multi/_history.py
+++ b/src/physbo/search/discrete_multi/_history.py
@@ -10,6 +10,7 @@ import pickle
 import copy
 
 from .. import pareto
+from .. import utility
 
 MAX_SEARCH = int(30000)
 
@@ -45,6 +46,36 @@ class History(object):
     @property
     def time_run_simulator(self):
         return copy.copy(self._time_run_simulator[0 : self.num_runs])
+
+    @property
+    def valid_mask(self):
+        """
+        Mask of valid observations (True) vs failed ones (False).
+
+        An observation is failed when any of its objective values is not
+        finite (NaN or +-Inf). Failed observations are kept in the history
+        but excluded from the training data and the Pareto front.
+
+        Returns
+        -------
+        numpy.ndarray of bool, shape (total_num_search,)
+        """
+        return utility.finite_mask(self.fx[0 : self.total_num_search])
+
+    def export_valid(self):
+        """
+        Export the valid (successfully evaluated) observations.
+
+        Returns
+        -------
+        actions: numpy.ndarray
+            Indexes of the actions of the valid observations.
+        fx: numpy.ndarray
+            Objective values of the valid observations (N_valid x num_objectives).
+        """
+        N = self.total_num_search
+        mask = self.valid_mask
+        return self.chosen_actions[0:N][mask], self.fx[0:N][mask]
 
     def write(
         self,

--- a/src/physbo/search/discrete_multi/_policy.py
+++ b/src/physbo/search/discrete_multi/_policy.py
@@ -113,16 +113,24 @@ class Policy(discrete.Policy):
             else:
                 Z = None
 
-        if self.new_data is None:
-            self.new_data = Variable(X=X, t=t, Z=Z)
-        else:
-            self.new_data.add(X=X, t=t, Z=Z)
+        # Failed observations (any non-finite objective) are kept in the
+        # history and their actions are consumed, but they are not used
+        # for training.
+        valid = utility.finite_mask(t)
+        if np.any(valid):
+            X_ok = np.asarray(X)[valid]
+            t_ok = t[valid]
+            Z_ok = utility.mask_rows(Z, valid)
+            if self.new_data is None:
+                self.new_data = Variable(X=X_ok, t=t_ok, Z=Z_ok)
+            else:
+                self.new_data.add(X=X_ok, t=t_ok, Z=Z_ok)
 
-        # Add to single training Variable with full 2D t matrix and (k, N, n) Z
-        if self.training.X is None:
-            self.training = Variable(X=X, t=t, Z=Z)
-        else:
-            self.training.add(X=X, t=t, Z=Z)
+            # Add to single training Variable with full 2D t matrix and (k, N, n) Z
+            if self.training.X is None:
+                self.training = Variable(X=X_ok, t=t_ok, Z=Z_ok)
+            else:
+                self.training.add(X=X_ok, t=t_ok, Z=Z_ok)
 
         # remove action from candidates if exists
         if len(self.actions) > 0:
@@ -606,9 +614,9 @@ class Policy(discrete.Policy):
         self.history.load(file_history)
 
         if file_training_list is None:
-            N = self.history.total_num_search
-            X = self.test.X[self.history.chosen_actions[0:N], :]
-            t = self.history.fx[0:N]
+            # rebuild the training data from the valid observations only
+            actions, t = self.history.export_valid()
+            X = self.test.X[actions, :]
             self.training = Variable(X=X, t=t)
         else:
             self.load_training_list(file_training_list)

--- a/src/physbo/search/discrete_unified/_history.py
+++ b/src/physbo/search/discrete_unified/_history.py
@@ -10,6 +10,7 @@ import pickle
 import copy
 
 from .. import pareto
+from .. import utility
 
 MAX_SEARCH = int(30000)
 
@@ -45,6 +46,36 @@ class History(object):
     @property
     def time_run_simulator(self):
         return copy.copy(self._time_run_simulator[0 : self.num_runs])
+
+    @property
+    def valid_mask(self):
+        """
+        Mask of valid observations (True) vs failed ones (False).
+
+        An observation is failed when any of its objective values is not
+        finite (NaN or +-Inf). Failed observations are kept in the history
+        but excluded from the training data and the Pareto front.
+
+        Returns
+        -------
+        numpy.ndarray of bool, shape (total_num_search,)
+        """
+        return utility.finite_mask(self.fx[0 : self.total_num_search])
+
+    def export_valid(self):
+        """
+        Export the valid (successfully evaluated) observations.
+
+        Returns
+        -------
+        actions: numpy.ndarray
+            Indexes of the actions of the valid observations.
+        fx: numpy.ndarray
+            Objective values of the valid observations (N_valid x num_objectives).
+        """
+        N = self.total_num_search
+        mask = self.valid_mask
+        return self.chosen_actions[0:N][mask], self.fx[0:N][mask]
 
     def write(
         self,

--- a/src/physbo/search/discrete_unified/_policy.py
+++ b/src/physbo/search/discrete_unified/_policy.py
@@ -119,16 +119,24 @@ class Policy(discrete.Policy):
         else:
             Z = None
 
-        if self.new_data is None:
-            self.new_data = Variable(X=X, t=t, Z=Z)
-        else:
-            self.new_data.add(X=X, t=t, Z=Z)
+        # Failed observations (any non-finite objective) are kept in the
+        # history and their actions are consumed, but they are not used
+        # for training.
+        valid = utility.finite_mask(t)
+        if np.any(valid):
+            X_ok = np.asarray(X)[valid]
+            t_ok = t[valid]
+            Z_ok = utility.mask_rows(Z, valid)
+            if self.new_data is None:
+                self.new_data = Variable(X=X_ok, t=t_ok, Z=Z_ok)
+            else:
+                self.new_data.add(X=X_ok, t=t_ok, Z=Z_ok)
 
-        # Add to single training Variable with full 2D t matrix and (k, N, n) Z
-        if self.training.X is None:
-            self.training = Variable(X=X, t=t, Z=Z)
-        else:
-            self.training.add(X=X, t=t, Z=Z)
+            # Add to single training Variable with full 2D t matrix and (k, N, n) Z
+            if self.training.X is None:
+                self.training = Variable(X=X_ok, t=t_ok, Z=Z_ok)
+            else:
+                self.training.add(X=X_ok, t=t_ok, Z=Z_ok)
 
         # remove action from candidates if exists
         if len(self.actions) > 0:
@@ -641,9 +649,9 @@ class Policy(discrete.Policy):
         self.history.load(file_history)
 
         if file_training is None:
-            N = self.history.total_num_search
-            X = self.test.X[self.history.chosen_actions[0:N], :]
-            t = self.history.fx[0:N]
+            # rebuild the training data from the valid observations only
+            actions, t = self.history.export_valid()
+            X = self.test.X[actions, :]
             self.training = Variable(X=X, t=t)
         else:
             self.training = Variable()

--- a/src/physbo/search/pareto.py
+++ b/src/physbo/search/pareto.py
@@ -157,13 +157,22 @@ class Pareto(object):
 
         Pareto set is sorted on the first objective in ascending order.
         """
-        t = np.array(t)
+        t = np.array(t, dtype=float)
         if t.ndim == 1:
             t = t.reshape((1, -1))
         assert t.shape[1] == self.num_objectives
         N = t.shape[0]
 
         indices = self.num_compared + np.arange(N)
+
+        # failed observations (any non-finite objective) never join the
+        # front; they are skipped here while their indices are still
+        # consumed so that front_num keeps referring to the rows of t
+        valid = np.all(np.isfinite(t), axis=1)
+        if not np.all(valid):
+            t = t[valid]
+            indices = indices[valid]
+
         right_front, right_indices = _extract_non_dominated_points(t, indices, maximize=True)
         new_front, new_indices = _merge_fronts(self.front, right_front, self.front_num, right_indices, maximize=True)
 

--- a/src/physbo/search/range/_history.py
+++ b/src/physbo/search/range/_history.py
@@ -22,8 +22,9 @@ class History:
         self.action_X = np.zeros((MAX_SEARCH, self.dim), dtype=float)
         self.terminal_num_run = np.zeros(MAX_SEARCH, dtype=int)
 
-        self.best_index = np.zeros(MAX_SEARCH, dtype=int)
-        self.best_index[0] = 0
+        # index of the best valid observation so far; -1 until the first
+        # valid (finite) observation
+        self.best_index = np.full(MAX_SEARCH, -1, dtype=int)
 
         self.time_total_ = np.zeros(MAX_SEARCH, dtype=float)
         self.time_update_predictor_ = np.zeros(MAX_SEARCH, dtype=float)
@@ -45,6 +46,36 @@ class History:
     @property
     def time_run_simulator(self):
         return copy.copy(self.time_run_simulator_[0 : self.num_runs])
+
+    @property
+    def valid_mask(self):
+        """
+        Mask of valid observations (True) vs failed ones (False).
+
+        An observation is failed when its objective value is not finite
+        (NaN or +-Inf). Failed observations are kept in the history but
+        excluded from the training data and the best-value tracking.
+
+        Returns
+        -------
+        numpy.ndarray of bool, shape (total_num_search,)
+        """
+        return utility.finite_mask(self.fx[0 : self.total_num_search])
+
+    def export_valid(self):
+        """
+        Export the valid (successfully evaluated) observations.
+
+        Returns
+        -------
+        X: numpy.ndarray
+            Inputs of the valid observations (N_valid x dim).
+        fx: numpy.ndarray
+            Objective values of the valid observations.
+        """
+        N = self.total_num_search
+        mask = self.valid_mask
+        return self.action_X[0:N, :][mask], self.fx[0:N][mask]
 
     def write(
         self,
@@ -88,14 +119,14 @@ class History:
         self.fx[st:en] = t
         self.action_X[st:en, :] = action_X
 
+        # track the best valid observation; failed (non-finite) ones are
+        # skipped and best_index stays -1 until the first valid one
         for n in range(st, en):
-            if n == 0:
-                self.best_index[0] = 0
-                continue
-            if self.fx[n] > self.fx[self.best_index[n - 1]]:
+            prev = self.best_index[n - 1] if n > 0 else -1
+            if np.isfinite(self.fx[n]) and (prev < 0 or self.fx[n] > self.fx[prev]):
                 self.best_index[n] = n
             else:
-                self.best_index[n] = self.best_index[n - 1]
+                self.best_index[n] = prev
 
         self.num_runs += 1
         self.total_num_search += N
@@ -128,13 +159,16 @@ class History:
             The best X at each sequence.
         """
 
-        best_fx = np.zeros(self.num_runs, dtype=float)
-        best_X = np.zeros((self.num_runs, self.dim), dtype=float)
+        # NaN until the first valid observation
+        best_fx = np.full(self.num_runs, np.nan, dtype=float)
+        best_X = np.full((self.num_runs, self.dim), np.nan, dtype=float)
 
         for r in range(self.num_runs):
             n = self.terminal_num_run[r] - 1
-            best_fx[r] = self.fx[self.best_index[n]]
-            best_X[r, :] = self.action_X[self.best_index[n], :]
+            b = self.best_index[n]
+            if b >= 0:
+                best_fx[r] = self.fx[b]
+                best_X[r, :] = self.action_X[b, :]
 
         return best_fx, best_X
 
@@ -149,11 +183,14 @@ class History:
         best_actions: numpy.ndarray
         """
 
-        best_fx = np.zeros(self.total_num_search, dtype=float)
-        best_X = np.zeros((self.total_num_search, self.dim), dtype=float)
+        # NaN until the first valid observation
+        best_fx = np.full(self.total_num_search, np.nan, dtype=float)
+        best_X = np.full((self.total_num_search, self.dim), np.nan, dtype=float)
         for n in range(self.total_num_search):
-            best_fx[n] = self.fx[self.best_index[n]]
-            best_X[n, :] = self.action_X[self.best_index[n], :]
+            b = self.best_index[n]
+            if b >= 0:
+                best_fx[n] = self.fx[b]
+                best_X[n, :] = self.action_X[b, :]
         return best_fx, best_X
 
     def save(self, filename):
@@ -212,19 +249,19 @@ class History:
 
     def show_search_results(self, N):
         n = self.total_num_search
-        index = np.argmax(self.fx[0:n])
+        index = self.best_index[n - 1]
+        if index >= 0:
+            best_msg = f"current best f(x) = {self.fx[index]:.6f} (best action={self.action_X[index, :]})"
+        else:
+            best_msg = "current best f(x) = (no valid observation yet)"
 
         if N == 1:
             print(
                 f"{n:04d}-th step: f(x) = {self.fx[n - 1]:.6f} (action={self.action_X[n - 1, :]})"
             )
-            print(
-                f"   current best f(x) = {self.fx[index]:.6f} (best action={self.action_X[index, :]}) \n"
-            )
+            print("   " + best_msg + " \n")
         else:
-            print(
-                f"current best f(x) = {self.fx[index]:.6f} (best action={self.action_X[index, :]})"
-            )
+            print(best_msg)
 
             print("list of simulation results")
             st = self.total_num_search - N

--- a/src/physbo/search/range/_policy.py
+++ b/src/physbo/search/range/_policy.py
@@ -124,6 +124,9 @@ class Policy:
             N dimensional array (1D) or N x 1 dimensional array (2D).
             The negative energy of each search candidate (value of the objective function to be optimized).
             Will be normalized to (N, 1) shape internally.
+            A non-finite value (NaN or +-Inf) marks a failed evaluation:
+            the point is recorded in the history, but the observation is
+            excluded from the training data and the best-value tracking.
         time_total: numpy.ndarray
             N dimenstional array. The total elapsed time in each step.
             If None (default), filled by 0.0.
@@ -158,12 +161,19 @@ class Policy:
             Z = Z_basis[np.newaxis, :, :]  # (N, n) -> (1, N, n)
         else:
             Z = None
-        self.training.add(X=X, t=t_normalized, Z=Z)
+        # Failed observations (non-finite t) are kept in the history but
+        # they are not used for training.
+        valid = utility.finite_mask(t_normalized)
+        if np.any(valid):
+            X_ok = np.asarray(X)[valid]
+            t_ok = t_normalized[valid]
+            Z_ok = utility.mask_rows(Z, valid)
+            self.training.add(X=X_ok, t=t_ok, Z=Z_ok)
 
-        if self.new_data is None:
-            self.new_data = Variable(X=X, t=t_normalized, Z=Z)
-        else:
-            self.new_data.add(X=X, t=t_normalized, Z=Z)
+            if self.new_data is None:
+                self.new_data = Variable(X=X_ok, t=t_ok, Z=Z_ok)
+            else:
+                self.new_data.add(X=X_ok, t=t_ok, Z=Z_ok)
 
     def random_search(
         self, max_num_probes, num_search_each_probe=1, simulator=None, is_disp=True
@@ -651,9 +661,8 @@ class Policy:
         self.history.load(file_history)
 
         if file_training is None:
-            N = self.history.total_num_search
-            X = self.history.action_X[0:N, :]
-            t = self.history.fx[0:N]
+            # rebuild the training data from the valid observations only
+            X, t = self.history.export_valid()
             # Normalize t to (N, 1) shape
             t_normalized = normalize_t(t, k=1)
             self.training = Variable(X=X, t=t_normalized)

--- a/src/physbo/search/range_multi/_history.py
+++ b/src/physbo/search/range_multi/_history.py
@@ -10,6 +10,7 @@ import pickle
 import copy
 
 from .. import pareto
+from .. import utility
 
 MAX_SEARCH = int(30000)
 
@@ -46,6 +47,36 @@ class History(object):
     @property
     def time_run_simulator(self):
         return copy.copy(self._time_run_simulator[0 : self.num_runs])
+
+    @property
+    def valid_mask(self):
+        """
+        Mask of valid observations (True) vs failed ones (False).
+
+        An observation is failed when any of its objective values is not
+        finite (NaN or +-Inf). Failed observations are kept in the history
+        but excluded from the training data and the Pareto front.
+
+        Returns
+        -------
+        numpy.ndarray of bool, shape (total_num_search,)
+        """
+        return utility.finite_mask(self.fx[0 : self.total_num_search])
+
+    def export_valid(self):
+        """
+        Export the valid (successfully evaluated) observations.
+
+        Returns
+        -------
+        X: numpy.ndarray
+            Inputs of the valid observations (N_valid x dim).
+        fx: numpy.ndarray
+            Objective values of the valid observations (N_valid x num_objectives).
+        """
+        N = self.total_num_search
+        mask = self.valid_mask
+        return self.action_X[0:N, :][mask], self.fx[0:N][mask]
 
     def write(
         self,

--- a/src/physbo/search/range_multi/_policy.py
+++ b/src/physbo/search/range_multi/_policy.py
@@ -126,16 +126,23 @@ class Policy(range_single.Policy):
         else:
             Z = None
 
-        if self.new_data is None:
-            self.new_data = Variable(X=X, t=t, Z=Z)
-        else:
-            self.new_data.add(X=X, t=t, Z=Z)
+        # Failed observations (any non-finite objective) are kept in the
+        # history but they are not used for training.
+        valid = utility.finite_mask(t)
+        if np.any(valid):
+            X_ok = np.asarray(X)[valid]
+            t_ok = t[valid]
+            Z_ok = utility.mask_rows(Z, valid)
+            if self.new_data is None:
+                self.new_data = Variable(X=X_ok, t=t_ok, Z=Z_ok)
+            else:
+                self.new_data.add(X=X_ok, t=t_ok, Z=Z_ok)
 
-        # Add to single training Variable with full 2D t matrix and (k, N, n) Z
-        if self.training.X is None:
-            self.training = Variable(X=X, t=t, Z=Z)
-        else:
-            self.training.add(X=X, t=t, Z=Z)
+            # Add to single training Variable with full 2D t matrix and (k, N, n) Z
+            if self.training.X is None:
+                self.training = Variable(X=X_ok, t=t_ok, Z=Z_ok)
+            else:
+                self.training.add(X=X_ok, t=t_ok, Z=Z_ok)
 
     def random_search(
         self,
@@ -610,9 +617,8 @@ class Policy(range_single.Policy):
         self.history.load(file_history)
 
         if file_training_list is None:
-            N = self.history.total_num_search
-            X = self.history.action_X[0:N, :]
-            t = self.history.fx[0:N, :]
+            # rebuild the training data from the valid observations only
+            X, t = self.history.export_valid()
             self.training = Variable(X=X, t=t)
         else:
             self.load_training_list(file_training_list)

--- a/src/physbo/search/range_unified/_history.py
+++ b/src/physbo/search/range_unified/_history.py
@@ -10,6 +10,7 @@ import pickle
 import copy
 
 from .. import pareto
+from .. import utility
 
 MAX_SEARCH = int(30000)
 
@@ -46,6 +47,36 @@ class History(object):
     @property
     def time_run_simulator(self):
         return copy.copy(self._time_run_simulator[0 : self.num_runs])
+
+    @property
+    def valid_mask(self):
+        """
+        Mask of valid observations (True) vs failed ones (False).
+
+        An observation is failed when any of its objective values is not
+        finite (NaN or +-Inf). Failed observations are kept in the history
+        but excluded from the training data and the Pareto front.
+
+        Returns
+        -------
+        numpy.ndarray of bool, shape (total_num_search,)
+        """
+        return utility.finite_mask(self.fx[0 : self.total_num_search])
+
+    def export_valid(self):
+        """
+        Export the valid (successfully evaluated) observations.
+
+        Returns
+        -------
+        X: numpy.ndarray
+            Inputs of the valid observations (N_valid x dim).
+        fx: numpy.ndarray
+            Objective values of the valid observations (N_valid x num_objectives).
+        """
+        N = self.total_num_search
+        mask = self.valid_mask
+        return self.action_X[0:N, :][mask], self.fx[0:N][mask]
 
     def write(
         self,

--- a/src/physbo/search/range_unified/_policy.py
+++ b/src/physbo/search/range_unified/_policy.py
@@ -116,16 +116,22 @@ class Policy(range_single.Policy):
             "The number of objectives in t must be the same as num_objectives"
         )
 
-        if self.new_data is None:
-            self.new_data = Variable(X=X, t=t, Z=None)
-        else:
-            self.new_data.add(X=X, t=t, Z=None)
+        # Failed observations (any non-finite objective) are kept in the
+        # history but they are not used for training.
+        valid = utility.finite_mask(t)
+        if np.any(valid):
+            X_ok = np.asarray(X)[valid]
+            t_ok = t[valid]
+            if self.new_data is None:
+                self.new_data = Variable(X=X_ok, t=t_ok, Z=None)
+            else:
+                self.new_data.add(X=X_ok, t=t_ok, Z=None)
 
-        # Add to single training Variable with full 2D t matrix and (k, N, n) Z
-        if self.training.X is None:
-            self.training = Variable(X=X, t=t, Z=None)
-        else:
-            self.training.add(X=X, t=t, Z=None)
+            # Add to single training Variable with full 2D t matrix
+            if self.training.X is None:
+                self.training = Variable(X=X_ok, t=t_ok, Z=None)
+            else:
+                self.training.add(X=X_ok, t=t_ok, Z=None)
 
     def random_search(
         self,
@@ -531,9 +537,8 @@ class Policy(range_single.Policy):
         self.history.load(file_history)
 
         if file_training is None:
-            N = self.history.total_num_search
-            X = self.history.action_X[0:N, :]
-            t = self.history.fx[0:N, :]
+            # rebuild the training data from the valid observations only
+            X, t = self.history.export_valid()
             self.training = Variable(X=X, t=t)
         else:
             self.load_training(file_training)

--- a/src/physbo/search/utility.py
+++ b/src/physbo/search/utility.py
@@ -188,7 +188,8 @@ def plot_pareto_front(
     for i in range(steps_begin, steps_end):
         if i in front_num:
             undominated.append(i)
-        else:
+        elif np.all(np.isfinite(history.fx[i])):
+            # failed observations (non-finite values) are not plotted
             dominated.append(i)
         min_fx = np.minimum(min_fx, history.fx[i, [x, y]])
         max_fx = np.maximum(max_fx, history.fx[i, [x, y]])
@@ -343,6 +344,51 @@ def show_interactive_mode(simulator, history):
 def length_vector(t):
     N = len(t) if hasattr(t, "__len__") else 1
     return N
+
+
+def finite_mask(t):
+    """Return the mask of valid (finite) observations.
+
+    An observation is valid when all of its objective values are finite;
+    a NaN or an infinite value marks a failed evaluation.
+
+    Parameters
+    ----------
+    t: numpy.ndarray
+        N dimensional array (single objective) or N x k dimensional array
+        (k objectives) of objective values.
+
+    Returns
+    -------
+    mask: numpy.ndarray of bool, shape (N,)
+        True for valid observations, False for failed ones.
+    """
+    t = np.asarray(t, dtype=float)
+    if t.ndim <= 1:
+        return np.isfinite(t).reshape(-1)
+    return np.all(np.isfinite(t), axis=tuple(range(1, t.ndim)))
+
+
+def mask_rows(Z, mask):
+    """Select the observations given by mask from a basis array Z.
+
+    Parameters
+    ----------
+    Z: numpy.ndarray or None
+        (N, n) array, or (k, N, n) array (one basis per objective), or None.
+    mask: numpy.ndarray of bool, shape (N,)
+
+    Returns
+    -------
+    numpy.ndarray or None
+        Z restricted to the rows where mask is True (None if Z is None).
+    """
+    if Z is None:
+        return None
+    Z = np.asarray(Z)
+    if Z.ndim == 3:
+        return Z[:, mask, :]
+    return Z[mask]
 
 
 def is_learning(n, interval):

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -63,9 +63,10 @@ def test_bayes_search_with_single_training_point(X, sim):
 
 
 def test_nan_objective_value(X):
-    # current behavior: NaN objective values are stored in the history
-    # unchecked and break the subsequent GP fit; an explicit validation
-    # in write() would be an improvement
+    # a NaN objective value is a failed observation: it is recorded in the
+    # history and the candidate is consumed, but it is excluded from the
+    # training data, so the subsequent GP fit is unaffected
+    # (see test_failed_observations.py for the full contract)
     def simnan(action):
         action = np.asarray(action)
         val = -np.sum((X[action] - 0.5) ** 2, axis=1)
@@ -73,20 +74,17 @@ def test_nan_objective_value(X):
 
     policy = physbo.search.discrete.Policy(test_X=X)
     policy.set_seed(1)
-    policy.random_search(max_num_probes=len(X), simulator=simnan, is_disp=False)
-    assert np.isnan(policy.history.fx[: len(X)]).any()
+    policy.random_search(max_num_probes=len(X) - 1, simulator=simnan, is_disp=False)
+    n = policy.history.total_num_search
+    assert np.isnan(policy.history.fx[:n]).any()
+    assert not policy.history.valid_mask.all()
+    assert np.all(np.isfinite(policy.training.t))
 
-    # how the fit breaks is LAPACK-build dependent: potrf may detect the
-    # NaN and report an error (newer scipy/LAPACK builds -> LinAlgError),
-    # or "succeed" and silently poison the predictions (older builds)
-    try:
-        policy.bayes_search(
-            max_num_probes=1, simulator=simnan, score="EI", is_disp=False
-        )
-    except np.linalg.LinAlgError:
-        pass
-    else:
-        assert np.isnan(policy.get_post_fmean(X)).any()
+    res = policy.bayes_search(
+        max_num_probes=1, simulator=simnan, score="EI", is_disp=False
+    )
+    assert res.total_num_search == len(X)
+    assert np.all(np.isfinite(policy.get_post_fmean(X)))
 
 
 def test_get_score_dimension_mismatch():

--- a/tests/unit/test_failed_observations.py
+++ b/tests/unit/test_failed_observations.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2020- The University of Tokyo
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Failed observations (non-finite objective values).
+
+Contract: an evaluation whose objective value is not finite (NaN or +-Inf;
+for multi-objective problems, any objective) is a *failed* observation.
+It is recorded in the history as is and the candidate is consumed, but it
+is excluded from the training data, the best-value tracking, and the
+Pareto front.
+"""
+
+import os
+from itertools import product
+
+import numpy as np
+import numpy.testing
+import pytest
+
+physbo = pytest.importorskip("physbo")
+
+
+# ---------------------------------------------------------------- fixtures
+
+@pytest.fixture
+def X5():
+    return np.linspace(0.0, 1.0, 5).reshape(-1, 1)
+
+
+def f1(X):
+    return -np.sum((X - 0.5) ** 2, axis=-1)
+
+
+def f2(X):
+    X = np.atleast_2d(X)
+    return np.c_[-np.sum((X - 0.3) ** 2, axis=1), -np.sum((X - 0.7) ** 2, axis=1)]
+
+
+min_X = np.array([0.0, 0.0])
+max_X = np.array([1.0, 1.0])
+
+
+# ------------------------------------------------------------ single: discrete
+
+def test_discrete_write_failed(X5):
+    policy = physbo.search.discrete.Policy(test_X=X5)
+    actions = np.array([0, 1, 2, 3])
+    t = f1(X5[actions])
+    t[2] = np.nan  # action 2 failed
+    policy.write(actions, t)
+
+    h = policy.history
+    assert h.total_num_search == 4
+    assert np.isnan(h.fx[2])
+    numpy.testing.assert_array_equal(h.valid_mask, [True, True, False, True])
+    # the failed action is consumed
+    numpy.testing.assert_array_equal(policy.actions, [4])
+    # but excluded from the training data
+    assert policy.training.X.shape[0] == 3
+    assert np.all(np.isfinite(policy.training.t))
+    ok_actions, ok_fx = h.export_valid()
+    numpy.testing.assert_array_equal(ok_actions, [0, 1, 3])
+    numpy.testing.assert_array_equal(ok_fx, t[[0, 1, 3]])
+
+
+def test_discrete_inf_is_failed(X5):
+    policy = physbo.search.discrete.Policy(test_X=X5)
+    policy.write(np.array([0, 1]), np.array([np.inf, -np.inf]))
+    numpy.testing.assert_array_equal(policy.history.valid_mask, [False, False])
+    assert policy.training.X is None or policy.training.X.shape[0] == 0
+
+
+def test_discrete_best_fx_ignores_failed(X5):
+    policy = physbo.search.discrete.Policy(test_X=X5)
+    # first observation fails, then a valid one, then a failed "better" one
+    policy.write(np.array([0]), np.array([np.nan]))
+    policy.write(np.array([1]), np.array([-1.0]))
+    policy.write(np.array([2]), np.array([np.nan]))
+    policy.write(np.array([3]), np.array([-2.0]))
+
+    best_fx, best_actions = policy.history.export_all_sequence_best_fx()
+    assert np.isnan(best_fx[0])
+    numpy.testing.assert_array_equal(best_fx[1:], [-1.0, -1.0, -1.0])
+    numpy.testing.assert_array_equal(best_actions[1:], [1, 1, 1])
+
+    best_fx, best_actions = policy.history.export_sequence_best_fx()
+    assert np.isnan(best_fx[0])
+    numpy.testing.assert_array_equal(best_fx[1:], [-1.0, -1.0, -1.0])
+    numpy.testing.assert_array_equal(best_actions[1:], [1, 1, 1])
+
+    # display must not crash on NaN
+    policy.history.show_search_results(1)
+    policy.history.show_search_results(2)
+
+
+def test_discrete_bayes_search_after_failure(X5):
+    def simnan(action):
+        action = np.asarray(action)
+        return np.where(action == 2, np.nan, f1(X5[action]))
+
+    policy = physbo.search.discrete.Policy(test_X=X5)
+    policy.set_seed(1)
+    policy.random_search(max_num_probes=4, simulator=simnan, is_disp=False)
+    assert np.isnan(policy.history.fx[: policy.history.total_num_search]).any()
+
+    # the GP only sees valid observations: no LinAlgError, no NaN poisoning
+    res = policy.bayes_search(
+        max_num_probes=1, simulator=simnan, score="EI", is_disp=False
+    )
+    assert res.total_num_search == 5
+    assert np.all(np.isfinite(policy.get_post_fmean(X5)))
+    assert np.all(np.isfinite(policy.get_score("EI", xs=X5)))
+
+
+def test_discrete_saveload_reconstructs_valid_training(X5, tmp_path):
+    policy = physbo.search.discrete.Policy(test_X=X5)
+    policy.write(np.array([0, 1, 2]), np.array([-1.0, np.nan, -3.0]))
+    file_history = os.path.join(tmp_path, "history.npz")
+    policy.save(file_history)
+
+    policy2 = physbo.search.discrete.Policy(test_X=X5)
+    policy2.load(file_history)
+    numpy.testing.assert_array_equal(policy2.history.valid_mask, [True, False, True])
+    assert policy2.training.X.shape[0] == 2
+    assert np.all(np.isfinite(policy2.training.t))
+    # the failed action stays consumed
+    numpy.testing.assert_array_equal(policy2.actions, [3, 4])
+
+
+# --------------------------------------------------------------- single: range
+
+def test_range_write_failed():
+    policy = physbo.search.range.Policy(min_X=min_X, max_X=max_X)
+    X = np.array([[0.1, 0.1], [0.5, 0.5], [0.9, 0.9]])
+    t = np.array([-1.0, np.nan, -3.0])
+    policy.write(X, t)
+
+    h = policy.history
+    assert h.total_num_search == 3
+    numpy.testing.assert_array_equal(h.valid_mask, [True, False, True])
+    assert policy.training.X.shape[0] == 2
+    ok_X, ok_fx = h.export_valid()
+    numpy.testing.assert_array_equal(ok_X, X[[0, 2]])
+    numpy.testing.assert_array_equal(ok_fx, [-1.0, -3.0])
+
+
+def test_range_best_fx_ignores_failed():
+    policy = physbo.search.range.Policy(min_X=min_X, max_X=max_X)
+    policy.write(np.array([[0.1, 0.1]]), np.array([np.nan]))
+    policy.write(np.array([[0.2, 0.2]]), np.array([-1.0]))
+    policy.write(np.array([[0.3, 0.3]]), np.array([np.nan]))
+    policy.write(np.array([[0.4, 0.4]]), np.array([-2.0]))
+
+    best_fx, best_X = policy.history.export_all_sequence_best_fx()
+    assert np.isnan(best_fx[0])
+    numpy.testing.assert_array_equal(best_fx[1:], [-1.0, -1.0, -1.0])
+    numpy.testing.assert_array_equal(best_X[1:], [[0.2, 0.2]] * 3)
+
+    best_fx, best_X = policy.history.export_sequence_best_fx()
+    assert np.isnan(best_fx[0])
+    numpy.testing.assert_array_equal(best_fx[1:], [-1.0, -1.0, -1.0])
+
+    policy.history.show_search_results(1)
+    policy.history.show_search_results(2)
+
+
+def test_range_bayes_search_after_failure():
+    def simnan(X):
+        X = np.atleast_2d(X)
+        val = f1(X)
+        return np.where(X[:, 0] > 0.8, np.nan, val)
+
+    policy = physbo.search.range.Policy(min_X=min_X, max_X=max_X)
+    policy.set_seed(1)
+    policy.write(np.array([[0.9, 0.5], [0.2, 0.2], [0.5, 0.6]]), simnan(np.array([[0.9, 0.5], [0.2, 0.2], [0.5, 0.6]])))
+    assert np.isnan(policy.history.fx[0])
+    res = policy.bayes_search(
+        max_num_probes=1, simulator=simnan, score="EI", is_disp=False
+    )
+    assert res.total_num_search == 4
+    assert np.all(np.isfinite(policy.get_post_fmean(np.array([[0.5, 0.5]]))))
+
+
+def test_range_saveload_reconstructs_valid_training(tmp_path):
+    policy = physbo.search.range.Policy(min_X=min_X, max_X=max_X)
+    policy.write(
+        np.array([[0.1, 0.1], [0.5, 0.5], [0.9, 0.9]]), np.array([-1.0, np.nan, -3.0])
+    )
+    file_history = os.path.join(tmp_path, "history.npz")
+    policy.save(file_history)
+
+    policy2 = physbo.search.range.Policy(min_X=min_X, max_X=max_X)
+    policy2.load(file_history)
+    numpy.testing.assert_array_equal(policy2.history.valid_mask, [True, False, True])
+    assert policy2.training.X.shape[0] == 2
+    best_fx, _ = policy2.history.export_all_sequence_best_fx()
+    numpy.testing.assert_array_equal(best_fx, [-1.0, -1.0, -1.0])
+
+
+# ----------------------------------------------------------- multi / unified
+
+@pytest.fixture
+def grid2():
+    a = np.linspace(0.0, 1.0, 5)
+    return np.array(list(product(a, a)))
+
+
+DISCRETE_MULTI = ["discrete_multi", "discrete_unified"]
+RANGE_MULTI = ["range_multi", "range_unified"]
+
+
+def make_policy(kind, grid2):
+    mod = getattr(physbo.search, kind)
+    if kind.startswith("discrete"):
+        return mod.Policy(test_X=grid2, num_objectives=2)
+    return mod.Policy(min_X=min_X, max_X=max_X, num_objectives=2)
+
+
+def unify_kwargs(kind):
+    if kind.endswith("unified"):
+        return {"unify_method": physbo.search.unify.ParEGO(num_objectives=2)}
+    return {}
+
+
+@pytest.mark.parametrize("kind", DISCRETE_MULTI)
+def test_discrete_multi_write_failed(kind, grid2):
+    policy = make_policy(kind, grid2)
+    actions = np.array([0, 6, 12, 18])
+    t = f2(grid2[actions])
+    t[1, 0] = np.nan  # one objective failed -> the point failed
+    t[3, 1] = np.inf
+    policy.write(actions, t)
+
+    h = policy.history
+    assert h.total_num_search == 4
+    numpy.testing.assert_array_equal(h.valid_mask, [True, False, True, False])
+    # consumed, but excluded from the training data
+    assert 6 not in policy.actions and 18 not in policy.actions
+    assert policy.training.X.shape[0] == 2
+    assert np.all(np.isfinite(policy.training.t))
+    # the Pareto front never contains a failed point
+    front, front_num = h.export_pareto_front()
+    assert np.all(np.isfinite(front))
+    assert set(front_num).issubset({0, 2})
+    ok_actions, ok_fx = h.export_valid()
+    numpy.testing.assert_array_equal(ok_actions, [0, 12])
+    assert ok_fx.shape == (2, 2)
+
+
+@pytest.mark.parametrize("kind", DISCRETE_MULTI)
+def test_discrete_multi_bayes_search_after_failure(kind, grid2):
+    def simnan(action):
+        action = np.asarray(action)
+        t = f2(grid2[action])
+        t[action == 12, 0] = np.nan
+        return t
+
+    policy = make_policy(kind, grid2)
+    policy.set_seed(1)
+    policy.write(np.array([0, 12, 24, 6, 18]), simnan(np.array([0, 12, 24, 6, 18])))
+    res = policy.bayes_search(
+        max_num_probes=1, simulator=simnan, score="EI" if kind.endswith("unified") else "EHVI",
+        is_disp=False, **unify_kwargs(kind),
+    )
+    assert res.total_num_search == 6
+    front, _ = res.export_pareto_front()
+    assert np.all(np.isfinite(front))
+
+
+@pytest.mark.parametrize("kind", DISCRETE_MULTI)
+def test_discrete_multi_saveload(kind, grid2, tmp_path):
+    policy = make_policy(kind, grid2)
+    actions = np.array([0, 6, 12])
+    t = f2(grid2[actions])
+    t[1, 1] = np.nan
+    policy.write(actions, t)
+    file_history = os.path.join(tmp_path, "history.npz")
+    policy.save(file_history)
+
+    policy2 = make_policy(kind, grid2)
+    policy2.load(file_history)
+    numpy.testing.assert_array_equal(policy2.history.valid_mask, [True, False, True])
+    assert policy2.training.X.shape[0] == 2
+    assert 6 not in policy2.actions
+    front, front_num = policy2.history.export_pareto_front()
+    assert np.all(np.isfinite(front))
+
+
+@pytest.mark.parametrize("kind", RANGE_MULTI)
+def test_range_multi_write_failed(kind, grid2):
+    policy = make_policy(kind, grid2)
+    X = np.array([[0.1, 0.1], [0.5, 0.5], [0.9, 0.9]])
+    t = f2(X)
+    t[1, 0] = np.nan
+    policy.write(X, t)
+
+    h = policy.history
+    numpy.testing.assert_array_equal(h.valid_mask, [True, False, True])
+    assert policy.training.X.shape[0] == 2
+    front, front_num = h.export_pareto_front()
+    assert np.all(np.isfinite(front))
+    assert 1 not in front_num
+    ok_X, ok_fx = h.export_valid()
+    numpy.testing.assert_array_equal(ok_X, X[[0, 2]])
+
+
+@pytest.mark.parametrize("kind", RANGE_MULTI)
+def test_range_multi_bayes_search_after_failure(kind, grid2):
+    def simnan(X):
+        X = np.atleast_2d(X)
+        t = f2(X)
+        t[X[:, 0] > 0.8, 1] = np.nan
+        return t
+
+    policy = make_policy(kind, grid2)
+    policy.set_seed(1)
+    X0 = np.array([[0.9, 0.5], [0.2, 0.2], [0.5, 0.6], [0.3, 0.8]])
+    policy.write(X0, simnan(X0))
+    assert not policy.history.valid_mask[0]
+    res = policy.bayes_search(
+        max_num_probes=1, simulator=simnan, score="EI" if kind.endswith("unified") else "EHVI",
+        is_disp=False, **unify_kwargs(kind),
+    )
+    assert res.total_num_search == 5
+    front, _ = res.export_pareto_front()
+    assert np.all(np.isfinite(front))
+
+
+@pytest.mark.parametrize("kind", RANGE_MULTI)
+def test_range_multi_saveload(kind, grid2, tmp_path):
+    policy = make_policy(kind, grid2)
+    X = np.array([[0.1, 0.1], [0.5, 0.5], [0.9, 0.9]])
+    t = f2(X)
+    t[1, 0] = np.nan
+    policy.write(X, t)
+    file_history = os.path.join(tmp_path, "history.npz")
+    policy.save(file_history)
+
+    policy2 = make_policy(kind, grid2)
+    policy2.load(file_history)
+    numpy.testing.assert_array_equal(policy2.history.valid_mask, [True, False, True])
+    assert policy2.training.X.shape[0] == 2
+
+
+# ------------------------------------------------------------------- pareto
+
+def test_pareto_update_front_skips_non_finite():
+    from physbo.search.pareto import Pareto
+
+    pareto = Pareto(num_objectives=2)
+    pareto.update_front(np.array([[1.0, 3.0], [np.nan, 5.0], [3.0, 1.0], [2.0, np.inf]]))
+    front, front_num = pareto.export_front()
+    numpy.testing.assert_array_equal(front, [[1.0, 3.0], [3.0, 1.0]])
+    # indices keep referring to the rows passed to update_front
+    numpy.testing.assert_array_equal(front_num, [0, 2])
+    assert pareto.num_compared == 4
+    # only-failed batch does not update the front
+    pareto.update_front(np.array([[np.nan, np.nan]]))
+    assert not pareto.front_updated
+    assert pareto.num_compared == 5


### PR DESCRIPTION
## Summary

A simulator may now return `NaN` (or `±Inf`) for an evaluation that failed (diverged simulation, experiment that could not be carried out, ...). Such a *failed observation* is recorded in the history and its candidate is consumed, but it is excluded from the GP training data, the best-value tracking, and the Pareto front. Previously a `NaN` was accepted unchecked and broke the next `bayes_search()` far downstream (a cryptic `LinAlgError` from the Cholesky factorization, or silently NaN-poisoned predictions, depending on the LAPACK build).

## Contract

- **Valid observation**: all objective values are finite (`np.isfinite`).
- **Failed observation**: `NaN` or `±Inf`; for multi-objective problems, a point is failed if *any* of its objectives is non-finite.
- Failed observations are kept in `history.fx` as is, their actions stay in `history.chosen_actions` (so they are never re-proposed), and they count in `total_num_search`.
- They are excluded from: `policy.training` / `new_data`, `export_(all_)sequence_best_fx()`, the Pareto front, and the Pareto plots.
- Unevaluated candidates are still represented positionally (membership in `policy.actions` / the history fill pointer), not by a value.

## Changes

- `search/utility.py`: `finite_mask(t)` (row-wise validity) and `mask_rows(Z, mask)` (for `(N, n)` / `(k, N, n)` basis arrays).
- All six `History` classes: `valid_mask` property and `export_valid()` returning the valid `(actions | X, fx)` pairs.
- `discrete` / `range` `History`: best-value tracking skips failed values (`NaN` / `-1` until the first valid observation; `range` uses `best_index = -1` as the sentinel); `show_search_results` no longer argmaxes over `NaN`.
- `pareto.Pareto.update_front`: ignores non-finite rows while still consuming their indices, so `front_num` keeps referring to history rows.
- All six `Policy.write()`: only valid rows are added to the training data / `new_data`; `Policy.load()` rebuilds the training data via `export_valid()`.
- `plot_pareto_front`: failed observations are not plotted.
- Manual (en/ja, `install.rst`): documents the contract and the new accessors.

The on-disk history format is unchanged (`NaN` is stored as is), so existing saved histories load without conversion.

## Tests

- `tests/unit/test_failed_observations.py` (22 tests) covers all six policy variants: failed observations are kept with `valid_mask == False`, candidates are consumed, training data / best values / Pareto front exclude them, `bayes_search` works after a failure, and save/load rebuilds the training data from valid observations only; plus `Pareto.update_front` index preservation.
- `tests/unit/test_edge_cases.py::test_nan_objective_value` is updated from pinning the old behavior (GP fit breaks on `NaN`) to the new contract (`bayes_search` completes with finite predictions), which also removes its LAPACK-build-dependent branch.
- Full suite on this branch: 300 passed (`tests/unit` + `tests/integrated`) plus the MPI consistency tests.

## Notes

- The `NaN` value itself is the failure marker; no separate status array is introduced. A numeric-but-failed observation (e.g., a penalty value) is therefore not expressible — out of scope for now.
- The `feature/checkpoint` / `feature/rng-refactor` branches touch `_history.py` / `_policy.py` as well; since the history format is unchanged here, the overlap should be limited to `write()` / `load()` hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)